### PR TITLE
Fix redis npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "buildDb": "docker build -t postgresdb . ",
     "upDb": "docker run -d --name postgresdb --rm -v /postgres-data:/var/lib/postgresql/data -p 7532:5432 postgresdb",
     "stopDb": "docker stop postgresdb",
-    "runRedis" : "docker run -d -p 6379:6379 --name redis --rm --network redisnet redis"
+    "runRedis" : "docker run -d -p 6379:6379 --name redis --rm -v redis:/data redis"
   },
   "dependencies": {
     "@bull-board/api": "^4.6.2",


### PR DESCRIPTION
Added redis volume to support persistence
Remove redis network (because we don't create it before and that's why we get an error: network redisnet not found) and why do we use the network at all?